### PR TITLE
Conditional Redirects added for some Nav Elements, Home/Signup/Logout

### DIFF
--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -1,10 +1,26 @@
 import Nav from "../Nav";
+import { Link } from "react-router-dom";
+import Auth from "../../utils/auth";
 
 function Header({ currentPage, setCurrentPage }){
     return(
-        <header className="top-header">
+        <header className="top-header bg-info bg-opacity-25">
             <div className="flex-container">
-                <a href="/" className="header-a custom-a"><h1 className="head-1">0nlyPets</h1></a>
+            {Auth.loggedIn() ? (
+            <Link
+                to={`/`}
+                className="custom-a">
+                    <h1 className="head-1">OnlyPets</h1>
+            </Link>
+            ):(
+                <Link
+                    to={`/Signup`}
+                    className="custom-a">
+                    <h1 className="head-1">OnlyPets</h1>
+                </Link>)
+                
+            }
+           
                 <Nav
                 currentPage={currentPage}
                 setCurrentPage={setCurrentPage}
@@ -15,3 +31,5 @@ function Header({ currentPage, setCurrentPage }){
 }
 
 export default Header;
+
+ 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,18 +1,25 @@
 // The pet feed of existing posts will be displayed here for everyone. Only logged in users can interact with the posts (comment, like)
 import React from "react";
 import PostList from "../components/PostList";
+import Auth from "../utils/auth";
+import { Redirect } from "react-router";
 
 //import Auth from "../utils/auth";
 import { useQuery } from "@apollo/client";
 import { QUERY_POSTS } from "../utils/queries";
 
 const Home = () => {
+  
   const { loading, data } = useQuery(QUERY_POSTS);
   //this doesnt seem to be needed for the home page
   //const { data: userData } = useQuery(QUERY_ME);
   const posts = data?.posts || [];
 
   const loggedIn = true; //Auth.loggedIn();
+
+  if (!Auth.loggedIn()) {
+    return <Redirect to="Signup"/>
+  }
 
   return (
     <main>


### PR DESCRIPTION
* When first opening the app: The SignUp Page is now the landing page. 
* When not logged in: OnlyPets title redirects to the SignUp Page
* When not logged in: Home automatically redirects to the SignUp Page
* Home is only viewable when logged in
* When logged in: the OnlyPets title redirects to home instead of SignUp
* When clicking on sign out: logs the user out and redirects to the Signup page
* The blue color scheme was added back (sorry Naomi)
* Marked the other pull request as closed: no need to merge it.

